### PR TITLE
Fix voice personas endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -90,16 +90,10 @@ export function registerRoutes(app: Express): void {
   app.get('/api/voice/personas', async (req, res) => {
     try {
       const voices = await getAvailableVoices();
-      res.json({
+      res.json({ success: true, data: voices });
+    } catch (error) {
       logger.error({ err: error }, 'Failed to fetch voices');
-        data: voices
-      res.json({
-        success: false,
-        data: []
-      });
-        success: true,
-        data: []
-      });
+      res.json({ success: false, data: [] });
     }
   });
 


### PR DESCRIPTION
## Summary
- clean up `/api/voice/personas` route so it returns success or error state

## Testing
- `npm run check` *(fails: lead-scraper-broken.tsx and other server routes errors)*

------
https://chatgpt.com/codex/tasks/task_b_687399ef819483329448babe575bf3d0