### PR TITLE
refactor: load airtable key from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+AIRTABLE_API_KEY=your_airtable_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ yarn-error.log*
 # Environments
 .env
 .env.*
+!.env.example
 
 # Node modules
 node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # YoBotAssistant
+
+## Environment Variables
+
+The server expects an `AIRTABLE_API_KEY` environment variable to authorize API calls.
+Copy `.env.example` to `.env` and fill in your key.

--- a/client/src/.env
+++ b/client/src/.env
@@ -1,5 +1,5 @@
 ICLOUD_USERNAME=tlerfald@yahoo.com
 ICLOUD_PASSWORD=befc-gkmr-vazb-gxxa
-AIRTABLE_API_KEY=paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa
+AIRTABLE_API_KEY=
 AIRTABLE_BASE_ID=appCoAtCZdARb4AM2
 AIRTABLE_TABLE_NAME=Command Center · Metrics Tracker

--- a/client/src/lib/airtable.ts
+++ b/client/src/lib/airtable.ts
@@ -2,7 +2,7 @@
 // /lib/airtable.ts
 import axios from 'axios';
 
-const AIRTABLE_API_KEY = "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY as string;
 const BASE_ID = "appRt8V3tH4g5Z51f";
 const TABLE_NAME = "Command Center - Metrics Tracker Table";
 

--- a/metrics.module.ts
+++ b/metrics.module.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY || "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 const BASE_ID = "appRt8V3tH4g5Z51f";
 const TABLE_NAME = "Command Center - Metrics Tracker Table";
 

--- a/server/modules/airtable/airtableLogger.ts
+++ b/server/modules/airtable/airtableLogger.ts
@@ -23,7 +23,7 @@ class AirtableLogger {
   constructor() {
     this.baseId = 'appRt8V3tH4g5Z5if';
     this.tableId = 'tbly0fjE2M5uHET9X';
-    this.apiKey = 'paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa';
+    this.apiKey = process.env.AIRTABLE_API_KEY || '';
     this.baseUrl = `https://api.airtable.com/v0/${this.baseId}/${this.tableId}`;
   }
 

--- a/server/modules/automation/automationBatch311_320.ts
+++ b/server/modules/automation/automationBatch311_320.ts
@@ -22,7 +22,7 @@ export async function logSupportTicketToAirtable(ticketId: string, subject: stri
       data,
       {
         headers: {
-          "Authorization": "Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa",
+          "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
           "Content-Type": "application/json"
         }
       }

--- a/server/modules/automation/automationBatch321_340.ts
+++ b/server/modules/automation/automationBatch321_340.ts
@@ -4,7 +4,7 @@ import axios from 'axios';
 const router = express.Router();
 
 // Airtable configuration
-const API_KEY = "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+const API_KEY = process.env.AIRTABLE_API_KEY;
 const BASE_ID = "appRt8V3tH4g5Z51f";
 const HEADERS = {
   "Authorization": `Bearer ${API_KEY}`,

--- a/server/modules/automation/automationSystemTest.ts
+++ b/server/modules/automation/automationSystemTest.ts
@@ -227,7 +227,7 @@ async function testAirtableConnection(): Promise<any> {
       try {
         const response = await axios.get(`${base.url}?maxRecords=1`, {
           headers: {
-            "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`
+            "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`
           }
         });
         

--- a/server/modules/command-center/commandCenterRoutes.ts
+++ b/server/modules/command-center/commandCenterRoutes.ts
@@ -98,7 +98,7 @@ async function logToAirtableQA(testData: {
     await fetch("https://api.airtable.com/v0/appRt8V3tH4g5Z5if/tbldPRZ4nHbtj9opU", {
       method: "POST",
       headers: {
-        "Authorization": "Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa",
+        "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
         "Content-Type": "application/json"
       },
       body: JSON.stringify({

--- a/server/modules/command-center/liveDashboardData.ts
+++ b/server/modules/command-center/liveDashboardData.ts
@@ -10,7 +10,7 @@ export class LiveDashboardData {
       // Get metrics from Airtable Integration Test Log Table
       const airtableResponse = await fetch("https://api.airtable.com/v0/appRt8V3tH4g5Z5if/tbly0fjE2M5uHET9X", {
         headers: {
-          "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`,
+          "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
           "Content-Type": "application/json"
         }
       });

--- a/server/modules/lead-scraper/scrapingPipeline.ts
+++ b/server/modules/lead-scraper/scrapingPipeline.ts
@@ -67,7 +67,7 @@ async function isDuplicate(email?: string, fullName?: string, domain?: string): 
   try {
     const airtableBaseId = "appRt8V3tH4g5Z5if";
     const airtableTableId = "tblPRZ4nHbtj9opU"; // 📥 Scraped Leads · Universal
-    const airtableToken = "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+    const airtableToken = process.env.AIRTABLE_API_KEY || '';
     const headers = {
       "Authorization": `Bearer ${airtableToken}`
     };
@@ -108,7 +108,7 @@ async function flagDuplicateInAirtable(recordId: string): Promise<boolean> {
   try {
     const airtableBaseId = "appRt8V3tH4g5Z5if";
     const airtableTableId = "tblPRZ4nHbtj9opU";
-    const airtableToken = "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+    const airtableToken = process.env.AIRTABLE_API_KEY || '';
 
     const url = `https://api.airtable.com/v0/${airtableBaseId}/${airtableTableId}/${recordId}`;
     const headers = {
@@ -135,7 +135,7 @@ async function updateExistingLead(recordId: string, email?: string, phone?: stri
   try {
     const airtableBaseId = "appRt8V3tH4g5Z5if";
     const airtableTableId = "tblPRZ4nHbtj9opU";
-    const airtableToken = "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+    const airtableToken = process.env.AIRTABLE_API_KEY || '';
 
     const url = `https://api.airtable.com/v0/${airtableBaseId}/${airtableTableId}/${recordId}`;
     const headers = {
@@ -186,7 +186,7 @@ async function pushToAirtableLeads(leadData: LeadData): Promise<boolean> {
     const airtableTableId = "tblPRZ4nHbtj9opU"; // 📥 Scraped Leads · Universal
     const airtableUrl = `https://api.airtable.com/v0/${airtableBaseId}/${airtableTableId}`;
     const headers = {
-      "Authorization": "Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa",
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
       "Content-Type": "application/json"
     };
     
@@ -248,7 +248,7 @@ async function updateSyncStatus(email: string, synced: boolean): Promise<void> {
   try {
     const airtableUrl = "https://api.airtable.com/v0/appCoAtCZdARb4AM2/tblScrapedLeads";
     const headers = {
-      "Authorization": "Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa"
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`
     };
 
     // Find record by email

--- a/server/modules/qa/qaValidationSystem.ts
+++ b/server/modules/qa/qaValidationSystem.ts
@@ -181,7 +181,7 @@ class QAValidationSystem {
       await fetch("https://api.airtable.com/v0/appRt8V3tH4g5Z5if/tbldPRZ4nHbtj9opU", {
         method: "POST",
         headers: {
-          "Authorization": "Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa",
+          "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
           "Content-Type": "application/json"
         },
         body: JSON.stringify({

--- a/server/modules/sales/salesOrderProcessor.ts
+++ b/server/modules/sales/salesOrderProcessor.ts
@@ -6,7 +6,7 @@ import axios from 'axios';
 
 // Configuration
 const GOOGLE_FOLDER_ID = "1-D1Do5bWsHWX1R7YexNEBLsgpBsV7WRh";
-const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY || "paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa";
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 const BASE_ID = "appRt8V3tH4g5Z5if";
 const TABLE_NAME = "📥 Scraped Leads (Universal)";
 

--- a/server/modules/voice/voiceCallbackSystem.ts
+++ b/server/modules/voice/voiceCallbackSystem.ts
@@ -48,7 +48,7 @@ export async function closeOutFollowupByPhone(phone: string): Promise<any> {
   try {
     const url = "https://api.airtable.com/v0/appRt8V3tH4g5Z5if/📞 Follow-Up Reminder Tracker";
     const headers = {
-      "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`,
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
       "Content-Type": "application/json"
     };
     
@@ -83,7 +83,7 @@ export async function logFollowupEventByPhone(phone: string, method: string, out
   try {
     const url = "https://api.airtable.com/v0/appRt8V3tH4g5Z5if/📞 Follow-Up Reminder Tracker";
     const headers = {
-      "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`,
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`,
       "Content-Type": "application/json"
     };
     
@@ -175,7 +175,7 @@ export async function statusMonitor(): Promise<any> {
   try {
     const url = "https://api.airtable.com/v0/appRt8V3tH4g5Z5if/📞 Follow-Up Reminder Tracker?filterByFormula={✅ Completed}=FALSE()";
     const headers = {
-      "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`
     };
     
     const response = await axios.get(url, { headers });
@@ -216,7 +216,7 @@ export async function dailySummaryPush(): Promise<any> {
     const pendingUrl = `https://api.airtable.com/v0/appRt8V3tH4g5Z5if/📞 Follow-Up Reminder Tracker?filterByFormula=AND({✅ Completed}=FALSE(), DATETIME_FORMAT({📅 Follow-Up Date}, 'YYYY-MM-DD')='${today}')`;
     
     const headers = {
-      "Authorization": `Bearer paty41tSgNrAPUQZV.7c0df078d76ad5bb4ad1f6be2adbf7e0dec16fd9073fbd51f7b64745953bddfa`
+      "Authorization": `Bearer ${process.env.AIRTABLE_API_KEY}`
     };
     
     const [completedResponse, pendingResponse] = await Promise.all([


### PR DESCRIPTION
## Summary
- remove hardcoded Airtable API tokens
- fetch Airtable token from `process.env.AIRTABLE_API_KEY`
- add `.env.example` and document required env variable

## Testing
- `npm run dev`
- `pytest`
- `pip install -r requirements.txt`
- `npm install`


------
https://chatgpt.com/codex/tasks/task_b_687390002038832995a81acb97b53f22