### PR TITLE
Enable JSON body parsing

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,6 +1,9 @@
 import express from "express";
 
 const app = express();
+
+// Parse JSON request bodies
+app.use(express.json());
 const PORT = process.env.PORT || 3000;
 
 app.get("/", (_req, res) => {


### PR DESCRIPTION
## Summary
- add JSON middleware to Express app

## Testing
- `node server/index.mjs`
- `curl -s http://localhost:3000/`

------
https://chatgpt.com/codex/tasks/task_b_6873a38162988332a1592467faa7701c