### PR TITLE
Use centralized Airtable config

### DIFF
--- a/metrics.module.ts
+++ b/metrics.module.ts
@@ -1,11 +1,13 @@
 import axios from "axios";
+import { AIRTABLE_BASES } from "./server/modules/airtable/airtableConfig";
 
+// Expects `AIRTABLE_API_KEY` in the environment for authentication
 const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 if (!AIRTABLE_API_KEY) {
   console.warn('AIRTABLE_API_KEY is not set');
 }
-const BASE_ID = "appRt8V3tH4g5Z51f";
-const TABLE_NAME = "Command Center - Metrics Tracker Table";
+const BASE_ID = AIRTABLE_BASES.COMMAND_CENTER.baseId;
+const TABLE_NAME = AIRTABLE_BASES.COMMAND_CENTER.tables.METRICS_TRACKER;
 
 const BASE_URL = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`;
 


### PR DESCRIPTION
## Summary
- use `airtableConfig` for Command Center base info
- document required env variable in metrics module

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6873a9fadc148332ae7b3478c4a5bb9b