### PR TITLE
Fix sales order Python script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Two helper scripts provide iCloud calendar syncing:
 
 * `app.py` – a small Flask server that schedules `sync_calendar_to_airtable` every 15 minutes.
 * `sync.py` – a standalone script for manual one‑off syncs.
+* `server/yobot_command_center/sales_order.py` – processes sales order data when triggered from the Express API.
 
 They require the same environment variables as above and the packages listed in `requirements.txt`.
 

--- a/server/modules/sales/productionSalesOrder.ts
+++ b/server/modules/sales/productionSalesOrder.ts
@@ -49,7 +49,8 @@ export function registerProductionSalesOrder(app: Express) {
       console.log(`💾 Real Tally submission saved: ${filename}`);
       
       // Process with live Tally processor
-      const pythonProcess = spawn('python3', ['live_tally_processor.py'], {
+      // Path updated to match new python script location
+      const pythonProcess = spawn('python3', ['server/yobot_command_center/sales_order.py'], {
         stdio: ['pipe', 'pipe', 'pipe']
       });
       
@@ -149,7 +150,8 @@ export function registerProductionSalesOrder(app: Express) {
       // Execute Python pipeline for all 10 steps
       console.log("🐍 Executing complete Python automation pipeline");
       
-      const pythonProcess = spawn('python3', ['server/completeProductionSalesOrder.py'], {
+      // Updated script path for production sales order pipeline
+      const pythonProcess = spawn('python3', ['server/yobot_command_center/sales_order.py'], {
         stdio: ['pipe', 'pipe', 'pipe']
       });
 


### PR DESCRIPTION
## Summary
- update `productionSalesOrder.ts` to call the correct Python script
- note the sales order script in the optional Python scripts section of the README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6873a9dd55b4833293019919586e2aaf