### PR TITLE
Remove fallback Airtable API keys

### DIFF
--- a/server/modules/airtable/airtable-api.ts
+++ b/server/modules/airtable/airtable-api.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from "express";
 
-const AIRTABLE_API_KEY = process.env.AIRTABLE_PERSONAL_ACCESS_TOKEN || process.env.AIRTABLE_VALID_TOKEN || process.env.AIRTABLE_API_KEY;
+const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
 const INTEGRATION_TEST_BASE = "appCoAtCZdARb4AM2";
 const INTEGRATION_TEST_TABLE = "🧪 Integration Test Log 2";
 const COMMAND_CENTER_BASE = "appRt8V3tH4g5Z51f";

--- a/server/modules/airtable/airtableLogger.ts
+++ b/server/modules/airtable/airtableLogger.ts
@@ -23,7 +23,7 @@ class AirtableLogger {
   constructor() {
     this.baseId = 'appRt8V3tH4g5Z5if';
     this.tableId = 'tbly0fjE2M5uHET9X';
-    this.apiKey = process.env.AIRTABLE_API_KEY || '';
+    this.apiKey = process.env.AIRTABLE_API_KEY as string;
     this.baseUrl = `https://api.airtable.com/v0/${this.baseId}/${this.tableId}`;
   }
 

--- a/server/modules/airtable/airtableService.ts
+++ b/server/modules/airtable/airtableService.ts
@@ -59,7 +59,7 @@ export class AirtableService {
   constructor() {
     this.config = {
       baseId: process.env.AIRTABLE_BASE_ID || 'appb2F3D77tC4DWla', // YoBot Lead Engine
-      apiKey: process.env.AIRTABLE_API_KEY || '',
+      apiKey: process.env.AIRTABLE_API_KEY as string,
       tables: {
         scrapedLeads: 'Scraped Leads (Universal) Table', // Scraped Leads (Universal)
         bookings: 'tblBookings',

--- a/server/modules/command-center/commandCenterMetrics.ts
+++ b/server/modules/command-center/commandCenterMetrics.ts
@@ -58,7 +58,7 @@ class CommandCenterMetrics {
   private localBackupLog: any[] = [];
 
   constructor() {
-    this.apiKey = process.env.AIRTABLE_API_KEY || '';
+    this.apiKey = process.env.AIRTABLE_API_KEY as string;
     if (!this.apiKey) {
       console.warn('AIRTABLE_API_KEY not configured for Command Center Metrics');
     }


### PR DESCRIPTION
## Summary
- ensure that Airtable integrations read the key only from `process.env.AIRTABLE_API_KEY`
- remove fallback values from Command Center modules

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6873a3586684833293ca3a0b8edc9905