### PR TITLE
Remove tracked env and use env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ client/src/pages/Command-Center.zip
 
 # Temporary text documents
 client/src/lib/New Text Document.txt
+client/src/.env

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,5 @@
+# Example variables for the client build
+AIRTABLE_API_KEY=
+AIRTABLE_BASE_ID=
+AIRTABLE_TABLE_NAME=
+SLACK_BOT_TOKEN=

--- a/client/src/.env
+++ b/client/src/.env
@@ -1,5 +1,0 @@
-ICLOUD_USERNAME=tlerfald@yahoo.com
-ICLOUD_PASSWORD=befc-gkmr-vazb-gxxa
-AIRTABLE_API_KEY=YOUR_AIRTABLE_API_KEY
-AIRTABLE_BASE_ID=appCoAtCZdARb4AM2
-AIRTABLE_TABLE_NAME=Command Center · Metrics Tracker

--- a/client/src/lib/airtable.ts
+++ b/client/src/lib/airtable.ts
@@ -3,11 +3,12 @@
 import axios from 'axios';
 
 const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
-if (!AIRTABLE_API_KEY) {
-  console.warn('AIRTABLE_API_KEY is not set');
+const BASE_ID = process.env.AIRTABLE_BASE_ID;
+const TABLE_NAME = process.env.AIRTABLE_TABLE_NAME;
+
+if (!AIRTABLE_API_KEY || !BASE_ID || !TABLE_NAME) {
+  console.warn('AIRTABLE_API_KEY, AIRTABLE_BASE_ID, or AIRTABLE_TABLE_NAME is not set');
 }
-const BASE_ID = "appRt8V3tH4g5Z51f";
-const TABLE_NAME = "Command Center - Metrics Tracker Table";
 
 const airtableInstance = axios.create({
   baseURL: `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`,

--- a/metrics.module.ts
+++ b/metrics.module.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
 
 const AIRTABLE_API_KEY = process.env.AIRTABLE_API_KEY;
-if (!AIRTABLE_API_KEY) {
-  console.warn('AIRTABLE_API_KEY is not set');
+const BASE_ID = process.env.AIRTABLE_BASE_ID;
+const TABLE_NAME = process.env.AIRTABLE_TABLE_NAME;
+
+if (!AIRTABLE_API_KEY || !BASE_ID || !TABLE_NAME) {
+  console.warn('AIRTABLE_API_KEY, AIRTABLE_BASE_ID, or AIRTABLE_TABLE_NAME is not set');
 }
-const BASE_ID = "appRt8V3tH4g5Z51f";
-const TABLE_NAME = "Command Center - Metrics Tracker Table";
 
 const BASE_URL = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`;
 


### PR DESCRIPTION
## Summary
- stop tracking `client/src/.env` and ignore it
- reference environment variables in `client/src/lib/airtable.ts` and `metrics.module.ts`
- provide `client/.env.example` for required keys
- add failing .env path to `.gitignore`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6873a9e9e034833292b47559bd7fa0a8