### PR TITLE
Fix Airtable exports and clean metrics module

### DIFF
--- a/metrics.module.ts
+++ b/metrics.module.ts
@@ -39,33 +39,3 @@ export async function fetchMetrics() {
     };
   }
 }
-
-
-const BASE_URL = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`;
-const headers = {
-  Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-};
-
-export async function fetchMetrics() {
-  try {
-    const response = await axios.get(BASE_URL, { headers });
-    const records = response.data.records;
-    const latest = records?.[0]?.fields || {};
-
-    return {
-      conversations: latest['fldcA7pxYCafK3DUw'] || 0,
-      messages: latest['fldfPk5WrGABynlHl'] || 0,
-      leads: latest['fldiGhisCfsshtBnP'] || 0,
-      revenue: latest['fldwvwGDKQ2c8E7Hx'] || 0,
-    };
-  } catch (error) {
-    console.error('Failed to fetch Airtable metrics:', error);
-    return {
-      conversations: 0,
-      messages: 0,
-      leads: 0,
-      revenue: 0,
-    };
-  }
-}
-

--- a/shared/airtableConfig.ts
+++ b/shared/airtableConfig.ts
@@ -16,44 +16,25 @@ export const COMMAND_CENTER_BASE_ID = 'appRt8V3tH4g5Z51f';
 export const LEAD_ENGINE_BASE_ID = 'appb2F3D77tC4DWla';
 export const OPS_BASE_ID = 'appCoAtCZdARb4AM2';
 
-export const METRICS_TABLE_NAME = 'Command Center - Metrics Tracker Table';
+export const METRICS_TABLE_NAME = '📊 Command Center · Metrics Tracker';
 export const SCRAPED_LEADS_TABLE_NAME = '📥 Scraped Leads (Universal)';
 export const SCRAPED_LEADS_TABLE_ID = 'tblPRZ4nHbtj9opU';
-export const INTEGRATION_TEST_LOG_TABLE = 'Integration Test Log Table';
-export const SALES_ORDERS_TABLE = 'Sales Orders';
+export const INTEGRATION_TEST_LOG_TABLE = '🧪 Integration Test Log';
+export const SALES_ORDERS_TABLE = '🧾 Sales Orders';
 
 export const TABLE_NAMES = {
   METRICS_TRACKER: METRICS_TABLE_NAME,
   SCRAPED_LEADS: SCRAPED_LEADS_TABLE_NAME,
   INTEGRATION_TEST_LOG: INTEGRATION_TEST_LOG_TABLE,
-
-export function getAirtableApiKey(): string {
-  return 'AIRTABLE_API_KEY';
-}
-
-export const COMMAND_CENTER_BASE_ID = 'appRt8V3tH4g5Z51f'; // Primary Command Center base
-export const LEAD_ENGINE_BASE_ID = 'appb2F3D77tC4DWla';   // YoBot Lead Engine
-export const OPS_BASE_ID = 'appCoAtCZdARb4AM2';          // Ops & Alerts base
-
-export const TABLE_NAMES = {
-  METRICS_TRACKER: '📊 Command Center · Metrics Tracker',
-  SCRAPED_LEADS: '📥 Scraped Leads (Universal)',
-  INTEGRATION_TEST_LOG: '🧪 Integration Test Log',
-
   FOLLOW_UP_REMINDER: '📞 Follow-Up Reminder Tracker',
   CCEVENTS: '📅 Calendar Events',
 };
 
+export const SCRAPED_LEADS_TABLE = SCRAPED_LEADS_TABLE_NAME;
 
 export function getAirtableApiKey(): string | undefined {
   return process.env.AIRTABLE_API_KEY;
 }
-
-export const SCRAPED_LEADS_TABLE = '📥 Scraped Leads (Universal)';
-export const SCRAPED_LEADS_TABLE_NAME = '📥 Scraped Leads (Universal)';
-export const SCRAPED_LEADS_TABLE_ID = 'tblPRZ4nHbtj9opU';
-export const SALES_ORDERS_TABLE = '🧾 Sales Orders';
-
 
 export function tableUrl(baseId: string, table: string): string {
   return `https://api.airtable.com/v0/${baseId}/${encodeURIComponent(table)}`;


### PR DESCRIPTION
## Summary
- close `getAirtableApiKey` block and deduplicate constants in `airtableConfig`
- remove duplicate function definitions in `metrics.module.ts`

## Testing
- `npm run check` *(fails: Missing script "check")*

------
https://chatgpt.com/codex/tasks/task_b_6876d73e62608332952ff4e826a68659