### PR TITLE
Remove duplicate exports in metrics module

### DIFF
--- a/metrics.module.ts
+++ b/metrics.module.ts
@@ -1,6 +1,10 @@
 import axios from "axios";
 
-import { COMMAND_CENTER_BASE_ID, TABLE_NAMES, getAirtableApiKey } from "./shared/airtableConfig";
+import {
+  COMMAND_CENTER_BASE_ID,
+  TABLE_NAMES,
+  getAirtableApiKey,
+} from "./shared/airtableConfig";
 import { AIRTABLE_BASES } from "./server/modules/airtable/airtableConfig";
 
 const AIRTABLE_API_KEY = getAirtableApiKey();
@@ -31,35 +35,6 @@ export async function fetchMetrics() {
     };
   } catch (error) {
     console.error("❌ Failed to fetch Airtable metrics:", error);
-    return {
-      conversations: 0,
-      messages: 0,
-      leads: 0,
-      revenue: 0,
-    };
-  }
-}
-
-
-const BASE_URL = `https://api.airtable.com/v0/${BASE_ID}/${encodeURIComponent(TABLE_NAME)}`;
-const headers = {
-  Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-};
-
-export async function fetchMetrics() {
-  try {
-    const response = await axios.get(BASE_URL, { headers });
-    const records = response.data.records;
-    const latest = records?.[0]?.fields || {};
-
-    return {
-      conversations: latest['fldcA7pxYCafK3DUw'] || 0,
-      messages: latest['fldfPk5WrGABynlHl'] || 0,
-      leads: latest['fldiGhisCfsshtBnP'] || 0,
-      revenue: latest['fldwvwGDKQ2c8E7Hx'] || 0,
-    };
-  } catch (error) {
-    console.error('Failed to fetch Airtable metrics:', error);
     return {
       conversations: 0,
       messages: 0,


### PR DESCRIPTION
## Summary
- cleanup metrics.module.ts
- remove duplicate definitions and consolidate imports

## Testing
- `npm run check` *(fails: Missing script or compilation errors)*

------
https://chatgpt.com/codex/tasks/task_b_6876d73b996083328578552a2db92680