### PR TITLE
Fix duplicate imports for COMMAND_CENTER_BASE_ID

### DIFF
--- a/server/modules/command-center/commandCenterMetrics.ts
+++ b/server/modules/command-center/commandCenterMetrics.ts
@@ -7,8 +7,6 @@
 
 import type { Express } from "express";
 
-import { COMMAND_CENTER_BASE_ID } from "../../config/airtableBase";
-
 import { COMMAND_CENTER_BASE_ID } from "@shared/airtableConfig";
 
 

--- a/server/modules/command-center/commandCenterRoutes.ts
+++ b/server/modules/command-center/commandCenterRoutes.ts
@@ -1,7 +1,5 @@
 import type { Express } from "express";
 
-import { COMMAND_CENTER_BASE_ID } from "../../config/airtableBase";
-
 import { COMMAND_CENTER_BASE_ID } from "@shared/airtableConfig";
 
 


### PR DESCRIPTION
## Summary
- clean up `COMMAND_CENTER_BASE_ID` imports in Command Center modules
- confirm TypeScript compile step

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_6876d73fe7448332b741d1e6b05413b1