### PR TITLE
chore: remove TypeScript project references

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,8 +46,6 @@
     "server",
     "vite.config.ts"
   ],
-  // Allows referencing other TypeScript projects.
-  "references": [],
   // Enable incremental compilation for faster builds
   "incremental": true
 }


### PR DESCRIPTION
Removed `"references"` field from `tsconfig.json` to resolve TypeScript project reference issues. This unblocks IDE errors and prevents unintended monorepo behavior.
